### PR TITLE
[FIXED JENKINS-26732] Fix startup problem if debian image hadn't been updated repositories

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -133,7 +133,7 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
 
                 // TODO: Add support for non-debian based java installations
                 // and let the user select the java version
-                if(conn.exec("apt-get install -y openjdk-7-jdk", logger) !=0) {
+                if(conn.exec("apt-get update -q && apt-get install -y openjdk-7-jdk", logger) !=0) {
                     logger.println("Failed to download Java");
                     return;
                 }


### PR DESCRIPTION
Fixing a typical apt problem that repositories need to be updated from
time to time since the installation of new packages isn't possible
otherwise.