### PR TITLE
Provide a more complete github landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Jenkins DigitalOcean Slave Plugin
 
 This Jenkins DigitalOcean plugin was inspired by the [ec2 plugin](https://github.com/jenkinsci/ec2-plugin) and uses the [java-digitalocean-api](https://github.com/jeevatkm/digitalocean-api-java) by [jeevatkm](https://github.com/jeevatkm) under the hood.
 
-## Limitations
+## Documentation
 
-- Only works with debian based droplets (link issue here)
+To keep a single place of truth the entire user documentation of the DigitalOcean Jenkins Slave Plugin is located in the [Jenkins Wiki Page](https://wiki.jenkins-ci.org/display/JENKINS/DigitalOcean+Plugin).
+
+## General Plugin Development Documentation
+
+The general information for developing jenkins plugins can be found [here](https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial).
+
+## Contribution
+
+For an howto on contributing read [this document](https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories).


### PR DESCRIPTION
This information should help future contributors to find an easier entry into contributing for this plugin. In addition it should give all required links into the documentation at one place.