### PR TITLE
Upgrade to latest jenkins LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.550</version>
+        <version>1.580.3</version>
     </parent>
 
     <groupId>com.dubture.jenkins</groupId>


### PR DESCRIPTION
The upgrade allows to support  building using the latest JDK version. In addition I think depending on the latest LTS version of jenkins should be fine.