### PR TITLE
[Fix JENKINS-27280] Start multiple DO container at once

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -161,7 +161,7 @@ public class Cloud extends AbstractCloudImpl {
         List<Droplet> availableDroplets = apiClient.getAvailableDroplets();
 
         for (Droplet droplet : availableDroplets) {
-            if (imageId == null || droplet.getImageId() == imageId) {
+            if (imageId == null || imageId.equals(droplet.getImageId())) {
                 if ("active".equals(droplet.getStatus()) || "new".equals(droplet.getStatus()) /*droplet.isActive() || droplet.isNew()*/) {
                     count++;
                 }
@@ -255,12 +255,13 @@ public class Cloud extends AbstractCloudImpl {
                     break;
                 }
 
-                nodes.add(new NodeProvisioner.PlannedNode(template.getDropletName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+                final String dropletName = template.createDropletName();
+                nodes.add(new NodeProvisioner.PlannedNode(dropletName, Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 
                     public Node call() throws Exception {
                         // TODO: record the output somewhere
                         try {
-                            Slave slave = template.provision(apiClient, privateKey, sshKeyId, new StreamTaskListener(System.out, Charset.defaultCharset()));
+                            Slave slave = template.provision(apiClient, dropletName, privateKey, sshKeyId, new StreamTaskListener(System.out, Charset.defaultCharset()));
                             Jenkins.getInstance().addNode(slave);
                             slave.toComputer().connect(false).get();
                             return slave;

--- a/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
@@ -51,6 +51,8 @@ public class Slave extends AbstractCloudSlave {
 
     private static final Logger LOG = Logger.getLogger(Slave.class.getName());
 
+    private final String cloudName;
+
     private final int idleTerminationTime;
 
     public final String initScript;
@@ -85,8 +87,9 @@ public class Slave extends AbstractCloudSlave {
      * @throws Descriptor.FormException
      * @throws IOException
      */
-    public Slave(String name, String nodeDescription, Integer dropletId, String privateKey, String remoteFS, String remoteAdmin, int numExecutors, int idleTerminationTime, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, String initScript, String jvmopts) throws Descriptor.FormException, IOException {
+    public Slave(String cloudName, String name, String nodeDescription, Integer dropletId, String privateKey, String remoteFS, String remoteAdmin, int numExecutors, int idleTerminationTime, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, String initScript, String jvmopts) throws Descriptor.FormException, IOException {
         super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
+        this.cloudName = cloudName;
         this.dropletId = dropletId;
         this.privateKey = privateKey;
         this.remoteAdmin = remoteAdmin;
@@ -123,7 +126,7 @@ public class Slave extends AbstractCloudSlave {
      * @return
      */
     public Cloud getCloud() {
-        return (Cloud) Hudson.getInstance().getCloud(name);
+        return (Cloud) Hudson.getInstance().getCloud(cloudName);
     }
 
     /**

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -253,7 +253,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public String createDropletName() {
-        return DROPLET_PREFIX + UUID.randomUUID().toString();
+        return "jenkins-" + UUID.randomUUID().toString();
     }
 
     public int getSizeId() {

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -82,11 +82,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public final Integer imageId;
 
     /**
-     * The name for the droplet (generated automatically)
-     */
-    private final String dropletName;
-
-    /**
      * The specified droplet size.
      */
     private final Integer sizeId;
@@ -113,9 +108,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      */
     @DataBoundConstructor
     public SlaveTemplate(String imageId, String sizeId, String regionId, String idleTerminationInMinutes, String labelString) {
-
-        // prefix the dropletname with jenkins_ so we know its created by us and can be re-used as a slave if needed
-        this.dropletName = DROPLET_PREFIX + UUID.randomUUID().toString();
         this.imageId = Integer.parseInt(imageId);
         this.sizeId = Integer.parseInt(sizeId);
         this.regionId = Integer.parseInt(regionId);
@@ -145,7 +137,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @throws ResourceNotFoundException
      * @throws Descriptor.FormException
      */
-    public Slave provision(DigitalOceanClient apiClient, String privateKey, Integer sshKeyId, StreamTaskListener listener) throws IOException, RequestUnsuccessfulException, AccessDeniedException, ResourceNotFoundException, Descriptor.FormException {
+    public Slave provision(DigitalOceanClient apiClient, String dropletName, String privateKey, Integer sshKeyId, StreamTaskListener listener) throws IOException, RequestUnsuccessfulException, AccessDeniedException, ResourceNotFoundException, Descriptor.FormException {
 
         PrintStream logger = listener.getLogger();
         try {
@@ -185,7 +177,24 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @throws Descriptor.FormException
      */
     private Slave newSlave(Droplet droplet, String privateKey) throws IOException, Descriptor.FormException {
-        return new Slave(getParent().getName(), droplet.getName(), droplet.getId(), privateKey, "/jenkins", "root", 1, idleTerminationInMinutes, Node.Mode.NORMAL, labels, new ComputerLauncher(), new RetentionStrategy(), Collections.<NodeProperty<?>>emptyList(), "", "");
+        return new Slave(
+                getParent().getName(),
+                droplet.getName(),
+                "Computer running on DigitalOcean with name: " + droplet.getName(),
+                droplet.getId(),
+                privateKey,
+                "/jenkins",
+                "root",
+                1,
+                idleTerminationInMinutes,
+                Node.Mode.NORMAL,
+                labels,
+                new ComputerLauncher(),
+                new RetentionStrategy(),
+                Collections.<NodeProperty<?>>emptyList(),
+                "",
+                ""
+        );
     }
 
     @Extension
@@ -243,8 +252,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return Hudson.getInstance().getDescriptor(getClass());
     }
 
-    public String getDropletName() {
-        return dropletName;
+    public String createDropletName() {
+        return DROPLET_PREFIX + UUID.randomUUID().toString();
     }
 
     public int getSizeId() {


### PR DESCRIPTION
Finally making multiple DigitalOcean containers from the same cloud as they should behave. This allows to create more than one container and also closing them again.