### PR TITLE
Create slaves from snapshots. configure num executors, ignore non-slave images

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -153,7 +153,7 @@ public class Cloud extends AbstractCloudImpl {
     public int countCurrentDropletsSlaves(String imageId) throws RequestUnsuccessfulException, DigitalOceanException {
         LOGGER.log(Level.INFO, "countCurrentDropletsSlaves(" + imageId + ")");
 
-        List<Droplet> availableDroplets = Utils.getDroplets(this.authToken);
+        List<Droplet> availableDroplets = DigitalOcean.getDroplets(this.authToken);
         int count = 0;
 
         for (Droplet droplet : availableDroplets) {
@@ -392,7 +392,7 @@ public class Cloud extends AbstractCloudImpl {
 
         public ListBoxModel doFillSshKeyIdItems(@QueryParameter String authToken) throws Exception {
 
-            List<Key> availableSizes = Utils.getAvailableKeys(authToken);
+            List<Key> availableSizes = DigitalOcean.getAvailableKeys(authToken);
             ListBoxModel model = new ListBoxModel();
 
             for (Key image : availableSizes) {

--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -78,6 +78,8 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public class Cloud extends AbstractCloudImpl {
 
+    public static final String SLAVE_NAME_REGEX = "^jenkins-\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}$";
+
     /**
      * The DigitalOcean API auth token
      * @see "https://developers.digitalocean.com/documentation/v2/#authentication"
@@ -158,8 +160,8 @@ public class Cloud extends AbstractCloudImpl {
         int count = 0;
 
         for (Droplet droplet : availableDroplets) {
-            if (imageId == null || imageId.equals(droplet.getImage().getSlug())) {
-                if (droplet.isActive() || droplet.isNew()) {
+            if (imageId == null || imageId.equals(droplet.getImage().getId().toString())) {
+                if ((droplet.isActive() || droplet.isNew()) && droplet.getName().matches(SLAVE_NAME_REGEX)) {
                     count++;
                 }
             }
@@ -238,12 +240,11 @@ public class Cloud extends AbstractCloudImpl {
             }
 
             LOGGER.log(Level.INFO,
-                    "Provisioning for AMI " + imageId + "; " +
+                    "Provisioning for " + imageId + "; " +
                             "Estimated number of total slaves: "
-                            + String.valueOf(estimatedTotalSlaves) + "; " +
+                            + estimatedTotalSlaves + "; " +
                             "Estimated number of slaves for imageId "
-                            + imageId + ": "
-                            + String.valueOf(estimatedDropletSlaves)
+                            + imageId + ": " + estimatedDropletSlaves
             );
 
             provisioningDroplets.put(imageId, currentProvisioning + 1);

--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -30,9 +30,7 @@ import com.myjeeva.digitalocean.exception.DigitalOceanException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import com.myjeeva.digitalocean.pojo.Droplet;
-import com.myjeeva.digitalocean.pojo.Droplets;
 import com.myjeeva.digitalocean.pojo.Key;
-import com.myjeeva.digitalocean.pojo.Keys;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -90,7 +88,6 @@ public class Cloud extends AbstractCloudImpl {
      * The SSH key to be added to the new droplet.
      */
     private final Integer sshKeyId;
-
 
     /**
      * The SSH private key associated with the selected SSH key
@@ -156,7 +153,7 @@ public class Cloud extends AbstractCloudImpl {
     public int countCurrentDropletsSlaves(String imageId) throws RequestUnsuccessfulException, DigitalOceanException {
         LOGGER.log(Level.INFO, "countCurrentDropletsSlaves(" + imageId + ")");
 
-        List<Droplet> availableDroplets = getDroplets();
+        List<Droplet> availableDroplets = Utils.getDroplets(this.authToken);
         int count = 0;
 
         for (Droplet droplet : availableDroplets) {
@@ -168,30 +165,6 @@ public class Cloud extends AbstractCloudImpl {
         }
 
         return count;
-    }
-
-    /**
-     * Fetches a list of all available droplets. The implementation will fetch all pages and return a single list
-     * of droplets.
-     * @return a list of all available droplets.
-     * @throws DigitalOceanException
-     * @throws RequestUnsuccessfulException
-     */
-    private List<Droplet> getDroplets() throws DigitalOceanException, RequestUnsuccessfulException {
-        LOGGER.log(Level.INFO, "Listing all droplets");
-        DigitalOceanClient apiClient = new DigitalOceanClient(this.authToken);
-        List<Droplet> availableDroplets = newArrayList();
-        Droplets droplets;
-        int page = 1;
-
-        do {
-            droplets = apiClient.getAvailableDroplets(page);
-            availableDroplets.addAll(droplets.getDroplets());
-            page += 1;
-        }
-        while (droplets.getMeta().getTotal() > page);
-
-        return availableDroplets;
     }
 
     /**
@@ -239,13 +212,9 @@ public class Cloud extends AbstractCloudImpl {
                 return false; // maxed out
             }
 
-            LOGGER.log(Level.INFO,
-                    "Provisioning for " + imageId + "; " +
-                            "Estimated number of total slaves: "
-                            + estimatedTotalSlaves + "; " +
-                            "Estimated number of slaves for imageId "
-                            + imageId + ": " + estimatedDropletSlaves
-            );
+            LOGGER.log(Level.INFO, "Provisioning for {0}; Estimated number of total slaves: {1}; " +
+                "Estimated number of slaves for imageId {0}: {2}",
+                new Object[] {imageId, estimatedTotalSlaves, estimatedDropletSlaves});
 
             provisioningDroplets.put(imageId, currentProvisioning + 1);
             return true;
@@ -423,7 +392,7 @@ public class Cloud extends AbstractCloudImpl {
 
         public ListBoxModel doFillSshKeyIdItems(@QueryParameter String authToken) throws Exception {
 
-            List<Key> availableSizes = getAvailableKeys(authToken);
+            List<Key> availableSizes = Utils.getAvailableKeys(authToken);
             ListBoxModel model = new ListBoxModel();
 
             for (Key image : availableSizes) {
@@ -432,24 +401,5 @@ public class Cloud extends AbstractCloudImpl {
 
             return model;
         }
-
-        private List<Key> getAvailableKeys(String authToken) throws RequestUnsuccessfulException, DigitalOceanException {
-
-            DigitalOceanClient client = new DigitalOceanClient(authToken);
-            List<Key> availableKeys = new ArrayList<Key>();
-
-            Keys keys;
-            int page = 1;
-
-            do {
-                keys = client.getAvailableKeys(page);
-                availableKeys.addAll(keys.getKeys());
-                page += 1;
-            }
-            while (keys.getMeta().getTotal() > page);
-
-            return availableKeys;
-        }
     }
-
 }

--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -32,9 +32,13 @@ import static com.google.common.collect.Lists.newArrayList;
  *
  * @author Rory Hunter (rory.hunter@blackpepper.co.uk)
  */
-public class Utils {
+public final class DigitalOcean {
 
-    private static final Logger LOGGER = Logger.getLogger(Utils.class.getName());
+    private DigitalOcean() {
+        throw new AssertionError();
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(DigitalOcean.class.getName());
 
     /**
      * Fetches all available droplet sizes.

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -24,17 +24,13 @@
 
 package com.dubture.jenkins.digitalocean;
 
-import com.myjeeva.digitalocean.exception.DigitalOceanException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import com.myjeeva.digitalocean.pojo.Droplet;
 import com.myjeeva.digitalocean.pojo.Image;
-import com.myjeeva.digitalocean.pojo.Images;
 import com.myjeeva.digitalocean.pojo.Key;
 import com.myjeeva.digitalocean.pojo.Region;
-import com.myjeeva.digitalocean.pojo.Regions;
 import com.myjeeva.digitalocean.pojo.Size;
-import com.myjeeva.digitalocean.pojo.Sizes;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.Util;
@@ -52,10 +48,11 @@ import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -211,65 +208,31 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
         public ListBoxModel doFillSizeIdItems(@RelativePath("..") @QueryParameter String authToken) throws Exception {
 
-            List<Size> availableSizes = getAvailableSizes(authToken);
+            List<Size> availableSizes = Utils.getAvailableSizes(authToken);
             ListBoxModel model = new ListBoxModel();
 
             for (Size size : availableSizes) {
-                model.add(size.getSlug());
+                model.add(Utils.buildSizeLabel(size), size.getSlug());
             }
 
             return model;
-        }
-
-        private static List<Size> getAvailableSizes(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
-            DigitalOceanClient client = new DigitalOceanClient(authToken);
-
-            List<Size> availableSizes = new ArrayList<Size>();
-            int page = 0;
-            Sizes sizes;
-
-            do {
-                page += 1;
-                sizes = client.getAvailableSizes(page);
-                availableSizes.addAll(sizes.getSizes());
-            }
-            while (sizes.getMeta().getTotal() > page);
-
-            return availableSizes;
         }
 
         public ListBoxModel doFillImageIdItems(@RelativePath("..") @QueryParameter String authToken) throws Exception {
 
-            List<Image> availableSizes = getAvailableImages(authToken);
+            SortedMap<String, Image> availableSizes = Utils.getAvailableImages(authToken);
             ListBoxModel model = new ListBoxModel();
 
-            for (Image image : availableSizes) {
-                model.add(image.getDistribution() + " " + image.getName(), image.getSlug());
+            for (Map.Entry<String, Image> entry : availableSizes.entrySet()) {
+                model.add(entry.getKey(), entry.getValue().getSlug());
             }
 
             return model;
         }
 
-        private static List<Image> getAvailableImages(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
-            DigitalOceanClient client = new DigitalOceanClient(authToken);
-
-            List<Image> availableSizes = new ArrayList<Image>();
-            Images images;
-            int page = 0;
-
-            do {
-                page += 1;
-                images = client.getAvailableImages(page);
-                availableSizes.addAll(images.getImages());
-            }
-            while (images.getMeta().getTotal() > page);
-
-            return availableSizes;
-        }
-
         public ListBoxModel doFillRegionIdItems(@RelativePath("..") @QueryParameter String authToken) throws Exception {
 
-            List<Region> availableSizes = getAvailableRegions(authToken);
+            List<Region> availableSizes = Utils.getAvailableRegions(authToken);
             ListBoxModel model = new ListBoxModel();
 
             for (Region region : availableSizes) {
@@ -278,24 +241,6 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             return model;
         }
-
-        private static List<Region> getAvailableRegions(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
-            DigitalOceanClient client = new DigitalOceanClient(authToken);
-
-            List<Region> availableRegions = new ArrayList<Region>();
-            Regions regions;
-            int page = 0;
-
-            do {
-                page += 1;
-                regions = client.getAvailableRegions(page);
-                availableRegions.addAll(regions.getRegions());
-            }
-            while (regions.getMeta().getTotal() > page);
-
-            return availableRegions;
-        }
-
     }
 
     public Descriptor<SlaveTemplate> getDescriptor() {

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -155,7 +155,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setName(dropletName);
             droplet.setSize(sizeId);
             droplet.setRegion(new Region(regionId));
-            droplet.setImage(new Image(imageId));
+            droplet.setImage(new Image(Integer.parseInt(imageId)));
             droplet.setKeys(newArrayList(new Key(sshKeyId)));
 
             logger.println("Creating slave with new droplet " + dropletName);
@@ -224,7 +224,9 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             ListBoxModel model = new ListBoxModel();
 
             for (Map.Entry<String, Image> entry : availableSizes.entrySet()) {
-                model.add(entry.getKey(), entry.getValue().getSlug());
+                // Reference image IDs instead of slugs so that we can build
+                // images based upon snapshots as well as standard images
+                model.add(entry.getKey(), entry.getValue().getId().toString());
             }
 
             return model;

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -60,12 +60,11 @@ import java.util.logging.Logger;
 import static com.google.common.collect.Lists.newArrayList;
 
 /**
- * A {@link com.dubture.jenkins.digitalocean.SlaveTemplate} represents the configuration values for creating a
- * new slave via a DigitalOcean droplet.
+ * A {@link SlaveTemplate} represents the configuration values for creating a new slave via a DigitalOcean droplet.
  *
- * Holds things like Image ID, sizeId and region used for the specific droplet.
+ * <p>Holds things like Image ID, sizeId and region used for the specific droplet.
  *
- * The {@link SlaveTemplate#provision(com.myjeeva.digitalocean.impl.DigitalOceanClient, String, String, Integer, hudson.util.StreamTaskListener)} method
+ * <p>The {@link SlaveTemplate#provision(DigitalOceanClient, String, String, Integer, hudson.util.StreamTaskListener)} method
  * is the main entry point to create a new droplet via the DigitalOcean API when a new slave needs to be provisioned.
  *
  * @author robert.gruendler@dubture.com
@@ -77,6 +76,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private final String labelString;
 
     private final int idleTerminationInMinutes;
+
+    /**
+     * The maximum number of executors that this slave will run.
+     */
+    private final int numExecutors;
 
     private final String labels;
 
@@ -108,16 +112,18 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param sizeId the image size e.g. "512mb" or "1gb"
      * @param regionId the region e.g. "nyc1"
      * @param idleTerminationInMinutes how long to wait before destroying a slave
+     * @param numExecutors the number of executors that this slave supports
      * @param labelString the label for this slave
      */
     @DataBoundConstructor
-    public SlaveTemplate(String imageId, String sizeId, String regionId, String idleTerminationInMinutes, String labelString) {
+    public SlaveTemplate(String imageId, String sizeId, String regionId, String idleTerminationInMinutes, String numExecutors, String labelString) {
         LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}", new Object[] { imageId, sizeId, regionId});
         this.imageId = imageId;
         this.sizeId = sizeId;
         this.regionId = regionId;
 
         this.idleTerminationInMinutes = Integer.parseInt(idleTerminationInMinutes);
+        this.numExecutors = Integer.parseInt(numExecutors);
         this.labelString = labelString;
         this.labels = Util.fixNull(labelString);
 
@@ -169,7 +175,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     /**
-     * Create a new {@link com.dubture.jenkins.digitalocean.Slave} from the given {@link com.myjeeva.digitalocean.pojo.Droplet}
+     * Create a new {@link Slave} from the given {@link Droplet}
      * @param droplet the droplet being created
      * @param privateKey the RSA private key being used
      * @return the provisioned {@link Slave}
@@ -186,7 +192,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 privateKey,
                 "/jenkins",
                 "root",
-                1,
+                numExecutors,
                 idleTerminationInMinutes,
                 Node.Mode.NORMAL,
                 labels,
@@ -282,7 +288,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     }
 
     public int getNumExecutors() {
-        return 1;
+        return numExecutors;
     }
 
     public int getIdleTerminationInMinutes() {

--- a/src/main/java/com/dubture/jenkins/digitalocean/Utils.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Utils.java
@@ -1,0 +1,150 @@
+package com.dubture.jenkins.digitalocean;
+
+import com.myjeeva.digitalocean.exception.DigitalOceanException;
+import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
+import com.myjeeva.digitalocean.impl.DigitalOceanClient;
+import com.myjeeva.digitalocean.pojo.Image;
+import com.myjeeva.digitalocean.pojo.Images;
+import com.myjeeva.digitalocean.pojo.Region;
+import com.myjeeva.digitalocean.pojo.Regions;
+import com.myjeeva.digitalocean.pojo.Size;
+import com.myjeeva.digitalocean.pojo.Sizes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Various utility methods that make it easier to obtain full lists of properties from Digital Ocean. Some API
+ * calls require page number, since the results are paginated, so these utilities will exhaust all the pages and
+ * return a single result set.
+ *
+ * @author Rory Hunter (rory.hunter@blackpepper.co.uk)
+ */
+public class Utils {
+
+    /**
+     * Fetches all available droplet sizes.
+     * @param authToken the API authorisation token to use
+     * @return a list of {@link Size}s, sorted by their memory capacity
+     * @throws DigitalOceanException
+     * @throws RequestUnsuccessfulException
+     */
+    public static List<Size> getAvailableSizes(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
+        DigitalOceanClient client = new DigitalOceanClient(authToken);
+
+        List<Size> availableSizes = new ArrayList<Size>();
+        int page = 0;
+        Sizes sizes;
+
+        do {
+            page += 1;
+            sizes = client.getAvailableSizes(page);
+            availableSizes.addAll(sizes.getSizes());
+        }
+        while (sizes.getMeta().getTotal() > page);
+
+        Collections.sort(availableSizes, new Comparator<Size>() {
+            @Override
+            public int compare(final Size s1, final Size s2) {
+                return s1.getMemorySizeInMb().compareTo(s2.getMemorySizeInMb());
+            }
+        });
+
+        return availableSizes;
+    }
+
+    /**
+     * Fetches all available images. Unlike the other getAvailable* methods, this returns a map because the values
+     * are sorted by a key composed of their OS distribution and version, which is useful for display purposes.
+     *
+     * @param authToken the API authorisation token to use
+     * @return a sorted map of {@link Image}s, key on their OS distribution and version
+     * @throws DigitalOceanException
+     * @throws RequestUnsuccessfulException
+     */
+    public static SortedMap<String,Image> getAvailableImages(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
+        DigitalOceanClient client = new DigitalOceanClient(authToken);
+
+        SortedMap<String,Image> availableImages = new TreeMap<String,Image>();
+        Images images;
+        int page = 0;
+
+        do {
+            page += 1;
+            images = client.getAvailableImages(page);
+            for (Image image : images.getImages()) {
+                availableImages.put(image.getDistribution() + " " + image.getName(), image);
+            }
+        }
+        while (images.getMeta().getTotal() > page);
+
+        return availableImages;
+    }
+
+    /**
+     * Fetches all regions that are flagged as available.
+     * @param authToken the API authorisation token to use
+     * @return a list of {@link Region}s, sorted by name.
+     * @throws DigitalOceanException
+     * @throws RequestUnsuccessfulException
+     */
+    public static List<Region> getAvailableRegions(String authToken) throws DigitalOceanException, RequestUnsuccessfulException {
+        DigitalOceanClient client = new DigitalOceanClient(authToken);
+
+        List<Region> availableRegions = new ArrayList<Region>();
+        Regions regions;
+        int page = 0;
+
+        do {
+            page += 1;
+            regions = client.getAvailableRegions(page);
+            for (Region region : regions.getRegions()) {
+                if (region.isAvailable()) {
+                    availableRegions.add(region);
+                }
+            }
+        }
+        while (regions.getMeta().getTotal() > page);
+
+        Collections.sort(availableRegions, new Comparator<Region>() {
+            @Override
+            public int compare(final Region r1, final Region r2) {
+                return r1.getName().compareTo(r2.getName());
+            }
+        });
+
+        return availableRegions;
+    }
+
+    /**
+     * Constructs a label for the given {@link Size}. Examples:
+     * <ul>
+     *     <li>"512mb / 20gb"</li>
+     *     <li>"1gb / 30gb"</li>
+     * </ul>
+     * @param size the size to use
+     * @return a label with memory and disk size
+     */
+    public static String buildSizeLabel(final Size size) {
+        /* It so happens that what we build here is the same as size.getSlug(),
+         * but I don't want to rely on that in case it changes.
+         */
+        int memory = size.getMemorySizeInMb();
+        String memoryUnits = "mb";
+
+        if (memory >= 1024) {
+            memory = memory / 1024;
+            memoryUnits = "gb";
+        }
+
+        return String.format("%d%s / %d%s",
+                memory,
+                memoryUnits,
+                size.getDiskSize(),
+                "gb");
+    }
+}

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-numExecutors.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-numExecutors.html
@@ -22,40 +22,6 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <table width="100%">
-
-        <f:entry title="Image" field="imageId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Size" field="sizeId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Region" field="regionId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Labels" field="labelString">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="Number of executors" field="numExecutors">
-            <f:textbox default="1" />
-        </f:entry>
-
-        <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:textbox default="10" />
-        </f:entry>
-
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton />
-            </div>
-        </f:entry>
-
-    </table>
-
-</j:jelly>
+<div>
+    Determines how many executors can run on the slave. Should be an integer greater than zero.
+</div>


### PR DESCRIPTION
Fix an issue where you couldn't create slaves from an image snapshot, because droplet creation was using name slugs. Switch to image IDs.

Allow the number of executors per slave to be configured.

When checking how many slaves are running, filter droplets by their image name. This avoids counting droplets that are unrelated to Jenkins.

Sort lists of objects for getter UX when configuring slaves.

Some other internal refactoring.