### PR TITLE
Support user data, init script and more!

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
@@ -56,11 +56,9 @@ public class Computer extends AbstractCloudComputer<Slave> {
         authToken = slave.getCloud().getAuthToken();
     }
 
-    public Droplet updateInstanceDescription() throws InterruptedException, RequestUnsuccessfulException, DigitalOceanException {
-
+    public Droplet updateInstanceDescription() throws RequestUnsuccessfulException, DigitalOceanException {
         DigitalOcean apiClient = new DigitalOceanClient(authToken);
-        Droplet dropletInfo = apiClient.getDropletInfo(dropletId);
-        return dropletInfo;
+        return apiClient.getDropletInfo(dropletId);
     }
 
     @Override

--- a/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
@@ -36,11 +36,9 @@ import java.util.logging.Logger;
 
 /**
  *
- * A {@link hudson.model.Computer} implementation for DigitalOcean.
+ * A {@link hudson.model.Computer} implementation for DigitalOcean. Holds a handle to an {@link Slave}.
  *
- * Holds a handle to an {@link com.dubture.jenkins.digitalocean.Slave}
- *
- * Mainly responsible for updating the {@link com.myjeeva.digitalocean.pojo.Droplet} information via {@link Computer#updateInstanceDescription()}
+ * <p>Mainly responsible for updating the {@link Droplet} information via {@link Computer#updateInstanceDescription()}
  *
  * @author robert.gruendler@dubture.com
  */

--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -40,7 +40,6 @@ import hudson.util.TimeUnit2;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.io.PrintStream;
 
@@ -208,6 +207,7 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
         // TODO: make configurable?
         final long timeout = TimeUnit2.MINUTES.toMillis(5);
         final long startTime = System.currentTimeMillis();
+        final int sleepTime = 10;
 
         while (true) {
             try {
@@ -227,7 +227,7 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
                 }
 
                 long waitTime = System.currentTimeMillis() - startTime;
-                if ( waitTime > timeout ) {
+                if (waitTime > timeout) {
                     throw new RuntimeException("Timed out after "+ (waitTime / 1000) + " seconds of waiting for ssh to become available. (maximum timeout configured is "+ (timeout / 1000) + ")" );
                 }
 
@@ -241,14 +241,15 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
                 int port = computer.getSshPort();
                 logger.println("Connecting to " + host + " on port " + port + ". ");
                 Connection conn = new Connection(host, port);
-                conn.connect();
+                conn.connect(null, 10, 0);
                 logger.println("Connected via SSH.");
                 return conn; // successfully connected
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 // keep retrying until SSH comes up
-                logger.println("Waiting for SSH to come up. Sleeping 5 seconds.");
+                logger.printf("Waiting for SSH to come up. Sleeping %d seconds.%n", sleepTime);
                 try {
-                    Thread.sleep(5000);
+                    Thread.sleep(10000);
                 }
                 catch (InterruptedException e2) {
                     // Ignore

--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -1,8 +1,10 @@
 package com.dubture.jenkins.digitalocean;
 
+import com.google.common.base.Function;
 import com.myjeeva.digitalocean.exception.DigitalOceanException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
+import com.myjeeva.digitalocean.pojo.Base;
 import com.myjeeva.digitalocean.pojo.Droplet;
 import com.myjeeva.digitalocean.pojo.Droplets;
 import com.myjeeva.digitalocean.pojo.Image;
@@ -14,6 +16,7 @@ import com.myjeeva.digitalocean.pojo.Regions;
 import com.myjeeva.digitalocean.pojo.Size;
 import com.myjeeva.digitalocean.pojo.Sizes;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -202,5 +205,18 @@ public final class DigitalOcean {
         while (droplets.getMeta().getTotal() > page);
 
         return availableDroplets;
+    }
+
+    /**
+     * Fetches information for the specified droplet.
+     * @param authToken the API authentication token to use
+     * @param dropletId the ID of the droplet to query
+     * @return information for the specified droplet
+     * @throws DigitalOceanException
+     * @throws RequestUnsuccessfulException
+     */
+    static Droplet getDroplet(String authToken, Integer dropletId) throws DigitalOceanException, RequestUnsuccessfulException {
+        LOGGER.log(Level.INFO, "Fetching droplet {0}", dropletId);
+        return new DigitalOceanClient(authToken).getDropletInfo(dropletId);
     }
 }

--- a/src/main/java/com/dubture/jenkins/digitalocean/RetentionStrategy.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/RetentionStrategy.java
@@ -24,14 +24,15 @@
 
 package com.dubture.jenkins.digitalocean;
 
+import com.myjeeva.digitalocean.pojo.Droplet;
 import hudson.model.Descriptor;
 import hudson.slaves.CloudSlaveRetentionStrategy;
 import hudson.util.TimeUnit2;
 
 /**
  *
- * The {@link com.dubture.jenkins.digitalocean.RetentionStrategy} is mainly used to determine
- * when an idle {@link com.myjeeva.digitalocean.pojo.Droplet} can be destroyed.
+ * The {@link RetentionStrategy} is mainly used to determine
+ * when an idle {@link Droplet} can be destroyed.
  *
  * @author robert.gruendler@dubture.com
  */

--- a/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
@@ -163,4 +163,8 @@ public class Slave extends AbstractCloudSlave {
     public String getUserData() {
         return userData;
     }
+
+    public String getInitScript() {
+        return initScript;
+    }
 }

--- a/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Slave.java
@@ -63,41 +63,31 @@ public class Slave extends AbstractCloudSlave {
 
     private final String privateKey;
 
+    private final String userData;
+
     private String remoteAdmin;
 
-    public final String jvmopts;
+    public final String jvmOpts;
 
     /**
-     *
-     * {@link com.dubture.jenkins.digitalocean.Slave}s are created by {@link com.dubture.jenkins.digitalocean.SlaveTemplate}s
-     *
-     * @param name
-     * @param nodeDescription
-     * @param dropletId
-     * @param privateKey
-     * @param remoteFS
-     * @param remoteAdmin
-     * @param numExecutors
-     * @param idleTerminationTime
-     * @param mode
-     * @param labelString
-     * @param launcher
-     * @param retentionStrategy
-     * @param nodeProperties
-     * @param initScript
-     * @param jvmopts
-     * @throws Descriptor.FormException
-     * @throws IOException
+     * {@link Slave}s are created by {@link SlaveTemplate}s
      */
-    public Slave(String cloudName, String name, String nodeDescription, Integer dropletId, String privateKey, String remoteFS, String remoteAdmin, int numExecutors, int idleTerminationTime, Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, String initScript, String jvmopts) throws Descriptor.FormException, IOException {
+    public Slave(String cloudName, String name, String nodeDescription, Integer dropletId, String privateKey,
+                 String remoteFS, String remoteAdmin, int numExecutors, int idleTerminationTime, String userData,
+                 Mode mode, String labelString, ComputerLauncher launcher, RetentionStrategy retentionStrategy,
+                 List<? extends NodeProperty<?>> nodeProperties, String initScript, String jvmOpts)
+            throws Descriptor.FormException, IOException {
+
         super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
+
         this.cloudName = cloudName;
         this.dropletId = dropletId;
         this.privateKey = privateKey;
         this.remoteAdmin = remoteAdmin;
         this.idleTerminationTime = idleTerminationTime;
+        this.userData = userData;
         this.initScript = initScript;
-        this.jvmopts = jvmopts;
+        this.jvmOpts = jvmOpts;
     }
 
     @Extension
@@ -168,5 +158,9 @@ public class Slave extends AbstractCloudSlave {
 
     public int getIdleTerminationTime() {
         return idleTerminationTime;
+    }
+
+    public String getUserData() {
+        return userData;
     }
 }

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -100,6 +100,11 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      */
     private final String regionId;
 
+    /**
+     * User-supplied data for configuring a droplet
+     */
+    private final String userData;
+
     private transient Set<LabelAtom> labelSet;
 
     protected transient Cloud parent;
@@ -115,10 +120,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param idleTerminationInMinutes how long to wait before destroying a slave
      * @param numExecutors the number of executors that this slave supports
      * @param labelString the label for this slave
+     * @param userData user data for DigitalOcean to apply when building the slave
      */
     @DataBoundConstructor
-    public SlaveTemplate(String imageId, String sizeId, String regionId, String idleTerminationInMinutes, String numExecutors, String labelString) {
-        LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}", new Object[] { imageId, sizeId, regionId});
+    public SlaveTemplate(String imageId, String sizeId, String regionId, String idleTerminationInMinutes,
+            String numExecutors, String labelString, String userData) {
+
+        LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}",
+            new Object[] { imageId, sizeId, regionId});
+
         this.imageId = imageId;
         this.sizeId = sizeId;
         this.regionId = regionId;
@@ -127,6 +137,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.numExecutors = tryParseInteger(numExecutors, 1);
         this.labelString = labelString;
         this.labels = Util.fixNull(labelString);
+
+        this.userData = userData;
 
         readResolve();
     }
@@ -143,13 +155,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @throws RequestUnsuccessfulException
      * @throws Descriptor.FormException
      */
-    public Slave provision(DigitalOceanClient apiClient, String dropletName, String privateKey, Integer sshKeyId, StreamTaskListener listener) throws IOException, RequestUnsuccessfulException, Descriptor.FormException {
+    public Slave provision(DigitalOceanClient apiClient, String dropletName, String privateKey, Integer sshKeyId, StreamTaskListener listener)
+            throws IOException, RequestUnsuccessfulException, Descriptor.FormException {
 
         LOGGER.log(Level.INFO, "Provisioning slave...");
 
         PrintStream logger = listener.getLogger();
         try {
-            logger.println("Starting to provision digital ocean droplet using image: " + imageId + ", region: " + regionId + ", sizeId: " + sizeId);
+            logger.printf("Starting to provision digital ocean droplet using image: %s, region: %s, sizeId: %s%n",
+                imageId, regionId, sizeId);
 
             // create a new droplet
             Droplet droplet = new Droplet();
@@ -158,6 +172,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setRegion(new Region(regionId));
             droplet.setImage(new Image(Integer.parseInt(imageId)));
             droplet.setKeys(newArrayList(new Key(sshKeyId)));
+
+            if (!(userData == null || userData.isEmpty())) {
+                droplet.setUserData(userData);
+            }
 
             logger.println("Creating slave with new droplet " + dropletName);
 
@@ -189,6 +207,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 "root",
                 numExecutors,
                 idleTerminationInMinutes,
+                userData,
                 Node.Mode.NORMAL,
                 labels,
                 new ComputerLauncher(),
@@ -289,6 +308,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public int getIdleTerminationInMinutes() {
         return idleTerminationInMinutes;
+    }
+
+    public String getUserData() {
+        return userData;
     }
 
     private static int tryParseInteger(final String integerString, final int defaultValue) {

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
@@ -1,0 +1,63 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2014 robert.gruendler@dubture.com
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+    <table width="100%">
+
+        <f:entry title="Image" field="imageId">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="Size" field="sizeId">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="Region" field="regionId">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="Labels" field="labelString">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="Number of executors" field="numExecutors">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="Idle termination time" field="idleTerminationInMinutes">
+            <f:readOnlyTextbox/>
+        </f:entry>
+
+        <f:entry title="User Data" field="userData">
+            <f:textarea/>
+        </f:entry>
+
+        <f:entry title="Init Script" field="initScript">
+            <f:textarea/>
+        </f:entry>
+
+    </table>
+
+</j:jelly>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
@@ -26,32 +26,16 @@
 
     <table width="100%">
 
-        <f:entry title="Image" field="imageId">
-            <f:readOnlyTextbox/>
-        </f:entry>
-
-        <f:entry title="Size" field="sizeId">
-            <f:readOnlyTextbox/>
-        </f:entry>
-
-        <f:entry title="Region" field="regionId">
-            <f:readOnlyTextbox/>
-        </f:entry>
-
         <f:entry title="Labels" field="labelString">
-            <f:readOnlyTextbox/>
+            <f:textbox/>
         </f:entry>
 
         <f:entry title="Number of executors" field="numExecutors">
-            <f:readOnlyTextbox/>
+            <f:textbox/>
         </f:entry>
 
         <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:readOnlyTextbox/>
-        </f:entry>
-
-        <f:entry title="User Data" field="userData">
-            <f:textarea/>
+            <f:textbox/>
         </f:entry>
 
         <f:entry title="Init Script" field="initScript">

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -47,7 +47,7 @@
         </f:entry>
 
         <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:textbox default="60" />
+            <f:textbox default="10" />
         </f:entry>
 
         <f:entry title="User Data" field="userData">

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-initScript.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-initScript.html
@@ -22,48 +22,7 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <table width="100%">
-
-        <f:entry title="Image" field="imageId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Size" field="sizeId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Region" field="regionId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Labels" field="labelString">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="Number of executors" field="numExecutors">
-            <f:textbox default="1" />
-        </f:entry>
-
-        <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:textbox default="60" />
-        </f:entry>
-
-        <f:entry title="User Data" field="userData">
-            <f:textarea/>
-        </f:entry>
-
-        <f:entry title="Init Script" field="initScript">
-            <f:textarea/>
-        </f:entry>
-
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton />
-            </div>
-        </f:entry>
-
-    </table>
-
-</j:jelly>
+<div>
+    Initialisation script to setup the slave. This differs from user data in that this is executed by Jenkins,
+    as opposed to DigitalOcean's provisioning process.
+</div>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-userData.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-userData.html
@@ -22,44 +22,10 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <table width="100%">
-
-        <f:entry title="Image" field="imageId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Size" field="sizeId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Region" field="regionId">
-            <f:select />
-        </f:entry>
-
-        <f:entry title="Labels" field="labelString">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="Number of executors" field="numExecutors">
-            <f:textbox default="1" />
-        </f:entry>
-
-        <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:textbox default="10" />
-        </f:entry>
-
-        <f:entry title="User Data" field="userData">
-            <f:textarea/>
-        </f:entry>
-
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton />
-            </div>
-        </f:entry>
-
-    </table>
-
-</j:jelly>
+<div>
+    User data is arbitrary data that a user can supply to a droplet during its creation time. User data can be
+    consumed by CloudInit, typically during the first boot of a cloud server, to perform tasks or run scripts as the
+    root user, which can be useful when provisioning a server. Read more on <a
+        href="https://www.digitalocean.com/community/tutorials/an-introduction-to-droplet-metadata"
+        >DigitalOcean's introduction to droplet metadata</a>.
+</div>


### PR DESCRIPTION
Support for configuring:
* Droplet user data
* Jenkins init script

Add a slave configure-entries.jelly to silence an exception when viewing the node's configuring. It's not great but it's better than nothing.

Check for an SSH connection less aggressively, and wait for the droplet to enter the ACTIVE state before doing so.

Increase default idle time to 60 minutes, since that's the minimum you'll pay for anyway.