### PR TITLE
Support both slugs and integers for identifying images

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -1,10 +1,9 @@
 package com.dubture.jenkins.digitalocean;
 
-import com.google.common.base.Function;
+import com.myjeeva.digitalocean.common.ImageType;
 import com.myjeeva.digitalocean.exception.DigitalOceanException;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
-import com.myjeeva.digitalocean.pojo.Base;
 import com.myjeeva.digitalocean.pojo.Droplet;
 import com.myjeeva.digitalocean.pojo.Droplets;
 import com.myjeeva.digitalocean.pojo.Image;
@@ -16,7 +15,6 @@ import com.myjeeva.digitalocean.pojo.Regions;
 import com.myjeeva.digitalocean.pojo.Size;
 import com.myjeeva.digitalocean.pojo.Sizes;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -94,7 +92,8 @@ public final class DigitalOcean {
             page += 1;
             images = client.getAvailableImages(page);
             for (Image image : images.getImages()) {
-                availableImages.put(image.getDistribution() + " " + image.getName(), image);
+                String prefix = image.getType() == ImageType.BACKUP ? "(Backup) " : "";
+                availableImages.put(prefix + image.getDistribution() + " " + image.getName(), image);
             }
         }
         while (images.getMeta().getTotal() > page);
@@ -216,7 +215,20 @@ public final class DigitalOcean {
      * @throws RequestUnsuccessfulException
      */
     static Droplet getDroplet(String authToken, Integer dropletId) throws DigitalOceanException, RequestUnsuccessfulException {
-        LOGGER.log(Level.INFO, "Fetching droplet {0}", dropletId);
+        LOGGER.log(Level.INFO, "Fetching droplet " + dropletId);
         return new DigitalOceanClient(authToken).getDropletInfo(dropletId);
+    }
+
+    static Image newImage(String idOrSlug) {
+        Image image;
+
+        try {
+            image = new Image(Integer.parseInt(idOrSlug));
+        }
+        catch (NumberFormatException e) {
+            image = new Image(idOrSlug);
+        }
+
+        return image;
     }
 }

--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -74,7 +74,8 @@ public final class DigitalOcean {
 
     /**
      * Fetches all available images. Unlike the other getAvailable* methods, this returns a map because the values
-     * are sorted by a key composed of their OS distribution and version, which is useful for display purposes.
+     * are sorted by a key composed of their OS distribution and version, which is useful for display purposes. Backup
+     * images are prefixed with "(Backup) " to easily differentiate them.
      *
      * @param authToken the API authorisation token to use
      * @return a sorted map of {@link Image}s, key on their OS distribution and version

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -24,6 +24,7 @@
 
 package com.dubture.jenkins.digitalocean;
 
+import com.myjeeva.digitalocean.common.ImageType;
 import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import com.myjeeva.digitalocean.pojo.Droplet;
@@ -253,28 +254,12 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             for (Map.Entry<String, Image> entry : availableImages.entrySet()) {
                 final Image image = entry.getValue();
-                final String value;
 
-                switch (image.getType()) {
-                    case SNAPSHOT:
-                        value = image.getSlug();
-                        break;
+                // For non-snapshots, use the image ID instead of the slug (which isn't available anyway)
+                // so that we can build images based upon backups.
+                final String value = image.getType() == ImageType.SNAPSHOT ? image.getSlug() : image.getId().toString();
 
-                    case BACKUP:
-                        // Use the image ID instead of the slug (which isn't available anyway)
-                        // so that we can build images based upon snapshots as well as standard images
-                        value = image.getId().toString();
-                        break;
-
-                    default:
-                        LOGGER.log(Level.WARNING, "Ignoring image of type " + image.getType());
-                        value = null;
-                        break;
-                }
-
-                if (value != null) {
-                    model.add(entry.getKey(), value);
-                }
+                model.add(entry.getKey(), value);
             }
 
             return model;

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Slave/configure-entries.jelly
@@ -38,10 +38,6 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="Init Script" field="initScript">
-            <f:textarea/>
-        </f:entry>
-
     </table>
 
 </j:jelly>


### PR DESCRIPTION
You can create droplets by ID or by slug. Currently the plugin always uses the ID, however DigitalOcean periodically update their standard snapshots, which appears to invalidate the old ID for their images. Change the plugin so that when configuring a droplet, it will use the slug for snapshots, but IDs for backups. Existing configuration is unaffected, because the code will always try to parse the stored imageId String as an Integer.

There is one caveat with this change - users that upgrade must note that if they change their droplet configuration, then they'll need to reset their image ID. Existing configuration will work without updates, since numeric image IDs are still supported for backup images. The flip side is that by using image slugs instead of IDs, you shouldn't get bitten when the standard image IDs change.

Also remove the init script from the slave view as it didn't need to be there.