### PR TITLE
Increase timeout for ssh connection

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -186,7 +186,7 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
     private Connection connectToSsh(Computer computer, PrintStream logger) throws RequestUnsuccessfulException, DigitalOceanException {
 
         // TODO: make configurable?
-        final long timeout = TimeUnit2.MINUTES.toMillis(5);
+        final long timeout = TimeUnit2.MINUTES.toMillis(15);
         final long startTime = System.currentTimeMillis();
         final int sleepTime = 10;
 


### PR DESCRIPTION
This is related to https://issues.jenkins-ci.org/browse/JENKINS-29904. The quickest fix is to increase the timeout.
A lot of CI images can be fairly large, and easily take over 5 minutes to complete.