### PR TITLE
Fixed paging issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.myjeeva.digitalocean</groupId>
             <artifactId>digitalocean-api-client</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
With the plugin using newer version of Digital Ocean API library, it started listing duplicate entries for droplet Regions, Images, SSH keys and other. This was caused by the paging code of the plugin.

This issue was mentioned in https://github.com/jenkinsci/digitalocean-plugin/pull/20#issuecomment-228525141