### PR TITLE
Add an option for label-less jobs

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -278,10 +278,9 @@ public class Cloud extends hudson.slaves.Cloud {
         List<SlaveTemplate> matchingTemplates = new ArrayList<SlaveTemplate>();
 
         for (SlaveTemplate t : templates) {
-            if (label == null && t.getLabelSet().size() != 0) {
-                continue;
-            }
-            if ((label == null && t.getLabelSet().size() == 0) || label.matches(t.getLabelSet())) {
+            if ((label == null && t.getLabelSet().size() == 0) ||
+                    (label == null && t.isLabellessJobsAllowed()) ||
+                    (label != null && label.matches(t.getLabelSet()))) {
                 matchingTemplates.add(t);
             }
         }

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -86,6 +86,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     private final String labels;
 
+    private final Boolean labellessJobsAllowed;
+
     /**
      * The Image to be used for the droplet.
      */
@@ -138,7 +140,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     @DataBoundConstructor
     public SlaveTemplate(String name, String imageId, String sizeId, String regionId, String username, String workspacePath,
                          Integer sshPort, String idleTerminationInMinutes, String numExecutors, String labelString,
-                         String instanceCap, String userData, String initScript) {
+                         Boolean labellessJobsAllowed, String instanceCap, String userData, String initScript) {
 
         LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}",
                 new Object[] { imageId, sizeId, regionId});
@@ -154,6 +156,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.idleTerminationInMinutes = tryParseInteger(idleTerminationInMinutes, 10);
         this.numExecutors = tryParseInteger(numExecutors, 1);
         this.labelString = labelString;
+        this.labellessJobsAllowed = labellessJobsAllowed;
         this.labels = Util.fixNull(labelString);
         this.instanceCap = Integer.parseInt(instanceCap);
 
@@ -438,6 +441,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public String getLabelString() {
         return labelString;
+    }
+
+    public boolean isLabellessJobsAllowed() {
+        return labellessJobsAllowed;
     }
 
     public Set<LabelAtom> getLabelSet() {

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -61,6 +61,10 @@
             <f:textbox/>
         </f:entry>
 
+        <f:entry title="Allow jobs with no label restriction" field="labellessJobsAllowed">
+            <f:checkbox/>
+        </f:entry>
+
         <f:entry title="Number of executors" field="numExecutors">
             <f:textbox default="1" />
         </f:entry>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-labellessJobsAllowed.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-labellessJobsAllowed.html
@@ -1,0 +1,36 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2016 Maxim Biro <nurupo.contributions@gmail.com>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    If there is non-empty set of labels specified and this is checked, jobs that are not restricted to run on any
+    specific node will trigger creation of a Droplet based on this Slave Template.
+
+    <P>
+    If there is non-empty set of labels specified and this is not checked, jobs that are not restricted to run on any
+    specific node will not trigger creation of a Droplet based on this Slave Template.
+
+    <P>
+    If no labels for this Slave Template are specified, then regardless of whether this option is checked or not, jobs
+    that are not restricted to run on any specific node will trigger creation of a Droplet based on this Slave Template.
+</div>


### PR DESCRIPTION
Previously, if a Slave Template had any labels set, a job not restricted to build on any node would not trigger creation of a Droplet based on such Slave Template. In fact, only Slave Templates with no labels specified were handling jobs not restricted to any label.

This commit adds an option which allows jobs not restricted to any node to trigger the creation of a Droplet based on a Slave Templates that has labels set.
