### PR TITLE
add cloud level configuration for initial connection retry sleeping

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2014 robert.gruendler@dubture.com
  *               2016 Maxim Biro <nurupo.contributions@gmail.com>
+ *               2017 Harald Sitter <sitter@kde.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -87,6 +88,8 @@ public class Cloud extends hudson.slaves.Cloud {
 
     private final Integer timeoutMinutes;
 
+    private final Integer connectionRetryWait;
+
     /**
      * List of {@link com.dubture.jenkins.digitalocean.SlaveTemplate}
      */
@@ -113,6 +116,7 @@ public class Cloud extends hudson.slaves.Cloud {
      * @param sshKeyId An identifier (name) for an SSH key known to DigitalOcean
      * @param instanceCap the maximum number of instances that can be started
      * @param timeoutMinutes
+     * @param connectionRetryWait the time to wait for SSH connections to work
      * @param templates the templates for this cloud
      */
     @DataBoundConstructor
@@ -122,6 +126,7 @@ public class Cloud extends hudson.slaves.Cloud {
             String sshKeyId,
             String instanceCap,
             String timeoutMinutes,
+            String connectionRetryWait,
             List<? extends SlaveTemplate> templates) {
         super(name);
 
@@ -132,6 +137,7 @@ public class Cloud extends hudson.slaves.Cloud {
         this.sshKeyId = Integer.parseInt(sshKeyId);
         this.instanceCap = Integer.parseInt(instanceCap);
         this.timeoutMinutes = timeoutMinutes == null || timeoutMinutes.isEmpty() ? 5 : Integer.parseInt(timeoutMinutes);
+        this.connectionRetryWait = connectionRetryWait == null || connectionRetryWait.isEmpty() ? 10 : Integer.parseInt(connectionRetryWait);
 
         if (templates == null) {
             this.templates = Collections.emptyList();
@@ -350,6 +356,10 @@ public class Cloud extends hudson.slaves.Cloud {
 
     public Integer getTimeoutMinutes() {
         return timeoutMinutes;
+    }
+
+    public Integer getConnectionRetryWait() {
+        return connectionRetryWait;
     }
 
     @Extension

--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2014 robert.gruendler@dubture.com
  *               2016 Maxim Biro <nurupo.contributions@gmail.com>
+ *               2017 Harald Sitter <sitter@kde.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -263,7 +264,7 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
 
         final long timeout = TimeUnit2.MINUTES.toMillis(computer.getCloud().getTimeoutMinutes());
         final long startTime = System.currentTimeMillis();
-        final int sleepTime = 10;
+        final int sleepTime = computer.getCloud().getConnectionRetryWait();
 
         long waitTime;
 

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
@@ -3,6 +3,7 @@
   ~
   ~ Copyright (c) 2014 robert.gruendler@dubture.com
   ~               2016 Maxim Biro <nurupo.contributions@gmail.com>
+  ~               2017 Harald Sitter <sitter@kde.org>
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +50,10 @@
 
     <f:entry title="Timeout in minutes" field="timeoutMinutes">
         <f:textbox default="5"/>
+    </f:entry>
+
+    <f:entry title="Connection retry wait in seconds" field="connectionRetryWait">
+        <f:textbox default="10"/>
     </f:entry>
 
     <f:validateButton title="Test connection" progress="Testing API connectivity..." method="testConnection" with="authToken"/>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/help-connectionRetryWait.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/help-connectionRetryWait.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 Harald Sitter <sitter@kde.org>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Seconds to sleep between retrying to connect to a newly created Droplet.
+    The longer the sleep, the less requests are needed to provision a new Droplet which may ease API request limit
+    exhaustion.
+    Shorter sleeping, while potentially causing more requests, reduces the amount of time until the new droplet can be
+    used.
+</div>


### PR DESCRIPTION
sleeping for only 10 seconds can quickly exhaust the api rate limit
with a lofty instance cap, or crappy provisioning failing half the time, or
bad response time to creation requests on the DO side (e.g. during
maintenance windows the time-to-droplet can rise by multiple minutes).

to prevent exhausting the rate limit make the retry sleeps configurable