### PR TITLE
add cloud level configuration for private networking

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -88,6 +88,8 @@ public class Cloud extends hudson.slaves.Cloud {
 
     private final Integer instanceCap;
 
+    private final Boolean usePrivateNetworking;
+
     private final Integer timeoutMinutes;
 
     private final Integer connectionRetryWait;
@@ -117,6 +119,7 @@ public class Cloud extends hudson.slaves.Cloud {
      * @param privateKey An RSA private key in text format
      * @param sshKeyId An identifier (name) for an SSH key known to DigitalOcean
      * @param instanceCap the maximum number of instances that can be started
+     * @param usePrivateNetworking Whether to use private networking to connect to the cloud.
      * @param timeoutMinutes
      * @param connectionRetryWait the time to wait for SSH connections to work
      * @param templates the templates for this cloud
@@ -127,6 +130,7 @@ public class Cloud extends hudson.slaves.Cloud {
             String privateKey,
             String sshKeyId,
             String instanceCap,
+            Boolean usePrivateNetworking,
             String timeoutMinutes,
             String connectionRetryWait,
             List<? extends SlaveTemplate> templates) {
@@ -138,6 +142,7 @@ public class Cloud extends hudson.slaves.Cloud {
         this.privateKey = privateKey;
         this.sshKeyId = Integer.parseInt(sshKeyId);
         this.instanceCap = Integer.parseInt(instanceCap);
+        this.usePrivateNetworking = usePrivateNetworking;
         this.timeoutMinutes = timeoutMinutes == null || timeoutMinutes.isEmpty() ? 5 : Integer.parseInt(timeoutMinutes);
         this.connectionRetryWait = connectionRetryWait == null || connectionRetryWait.isEmpty() ? 10 : Integer.parseInt(connectionRetryWait);
 
@@ -241,7 +246,7 @@ public class Cloud extends hudson.slaves.Cloud {
                                     return null;
                                 }
                                 slave = template.provision(provisioningId, dropletName, name, authToken, privateKey,
-                                                           sshKeyId, droplets);
+                                                           sshKeyId, droplets, usePrivateNetworking);
                             }
                             Jenkins.getInstance().addNode(slave);
                             slave.toComputer().connect(false).get();
@@ -364,6 +369,10 @@ public class Cloud extends hudson.slaves.Cloud {
 
     public Integer getConnectionRetryWait() {
         return connectionRetryWait;
+    }
+
+    public Boolean getUsePrivateNetworking() {
+        return usePrivateNetworking;
     }
 
     @Extension

--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -339,10 +339,12 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
     private static String getIpAddress(Computer computer) throws RequestUnsuccessfulException, DigitalOceanException {
         Droplet instance = computer.updateInstanceDescription();
 
+        final String networkType = computer.getCloud().getUsePrivateNetworking() ? "private" : "public";
+
         for (final Network network : instance.getNetworks().getVersion4Networks()) {
-            String host = network.getIpAddress();
-            if (host != null) {
-                return host;
+            LOGGER.log(Level.INFO, "network {0} => {1}", new Object[] {network.getIpAddress(), network.getType()});
+            if (network.getType().equals(networkType)) {
+                return network.getIpAddress();
             }
         }
 

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -206,7 +206,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                            String authToken,
                            String privateKey,
                            Integer sshKeyId,
-                           List<Droplet> droplets)
+                           List<Droplet> droplets,
+                           Boolean usePrivateNetworking)
             throws IOException, RequestUnsuccessfulException, Descriptor.FormException {
 
         LOGGER.log(Level.INFO, "Provisioning slave...");
@@ -225,6 +226,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setRegion(new Region(regionId));
             droplet.setImage(DigitalOcean.newImage(imageId));
             droplet.setKeys(newArrayList(new Key(sshKeyId)));
+            droplet.setEnablePrivateNetworking(usePrivateNetworking);
 
             if (!(userData == null || userData.trim().isEmpty())) {
                 droplet.setUserData(userData);

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
@@ -48,6 +48,10 @@
         <f:textbox default="5"/>
     </f:entry>
 
+    <f:entry field="usePrivateNetworking">
+        <f:checkbox title="Use private networking between master and cloud slaves"/>
+    </f:entry>
+
     <f:entry title="Timeout in minutes" field="timeoutMinutes">
         <f:textbox default="5"/>
     </f:entry>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/help-usePrivateNetworking.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/help-usePrivateNetworking.html
@@ -1,0 +1,30 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 Harald Sitter <sitter@kde.org>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Use digital ocean private IP to communicate between master and cloud slaves. This requires that the Jenkins master
+    has private networking enabled and is in the same data center as the cloud. Private network communication does not
+    count against transfer limits. This is not a measure of security, private networking is shared across all droplets
+    in a data center.
+</div>


### PR DESCRIPTION
iff the master and the cloud are within the same data center the master can
use the private network address of the slaves rather than their public one.
private traffic doesn't count against transfer limits and is usually also
a tad faster.