### PR TITLE
integrate with cloud-stats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>guava</artifactId>
             <version>15.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>cloud-stats</artifactId>
+            <version>0.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Computer.java
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2014 robert.gruendler@dubture.com
  *               2016 Maxim Biro <nurupo.contributions@gmail.com>
+ *               2017 Harald Sitter <sitter@kde.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +31,8 @@ import com.myjeeva.digitalocean.exception.RequestUnsuccessfulException;
 import com.myjeeva.digitalocean.impl.DigitalOceanClient;
 import com.myjeeva.digitalocean.pojo.Droplet;
 import hudson.slaves.AbstractCloudComputer;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
+import org.jenkinsci.plugins.cloudstats.TrackedItem;
 
 import java.util.logging.Logger;
 
@@ -41,9 +44,11 @@ import java.util.logging.Logger;
  *
  * @author robert.gruendler@dubture.com
  */
-public class Computer extends AbstractCloudComputer<Slave> {
+public class Computer extends AbstractCloudComputer<Slave> implements TrackedItem {
 
     private static final Logger LOGGER = Logger.getLogger(Computer.class.getName());
+
+    private final ProvisioningActivity.Id provisioningId;
 
     private final String authToken;
 
@@ -51,6 +56,7 @@ public class Computer extends AbstractCloudComputer<Slave> {
 
     public Computer(Slave slave) {
         super(slave);
+        provisioningId = slave.getId();
         dropletId = slave.getDropletId();
         authToken = slave.getCloud().getAuthToken();
     }
@@ -66,6 +72,11 @@ public class Computer extends AbstractCloudComputer<Slave> {
 
         LOGGER.info("Slave removed, deleting droplet " + dropletId);
         DigitalOcean.tryDestroyDropletAsync(authToken, dropletId);
+    }
+
+    @Override
+    public ProvisioningActivity.Id getId() {
+        return provisioningId;
     }
 
     public Cloud getCloud() {

--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2014 robert.gruendler@dubture.com
  *               2016 Maxim Biro <nurupo.contributions@gmail.com>
+ *               2017 Harald Sitter <sitter@kde.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +56,7 @@ import hudson.slaves.NodeProperty;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -198,7 +200,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return count >= instanceCap;
     }
 
-    public Slave provision(String dropletName, String cloudName, String authToken, String privateKey, Integer sshKeyId, List<Droplet> droplets)
+    public Slave provision(ProvisioningActivity.Id provisioningId,
+                           String dropletName,
+                           String cloudName,
+                           String authToken,
+                           String privateKey,
+                           Integer sshKeyId,
+                           List<Droplet> droplets)
             throws IOException, RequestUnsuccessfulException, Descriptor.FormException {
 
         LOGGER.log(Level.INFO, "Provisioning slave...");
@@ -227,7 +235,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             DigitalOceanClient apiClient = new DigitalOceanClient(authToken);
             Droplet createdDroplet = apiClient.createDroplet(droplet);
 
-            return newSlave(cloudName, createdDroplet, privateKey);
+            return newSlave(provisioningId, cloudName, createdDroplet, privateKey);
         } catch (Exception e) {
             LOGGER.log(Level.WARNING, e.getMessage(), e);
             throw new AssertionError();
@@ -242,9 +250,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @throws IOException
      * @throws Descriptor.FormException
      */
-    private Slave newSlave(String cloudName, Droplet droplet, String privateKey) throws IOException, Descriptor.FormException {
+    private Slave newSlave(ProvisioningActivity.Id provisioningId, String cloudName, Droplet droplet, String privateKey) throws IOException, Descriptor.FormException {
         LOGGER.log(Level.INFO, "Creating new slave...");
         return new Slave(
+                provisioningId,
                 cloudName,
                 droplet.getName(),
                 "Computer running on DigitalOcean with name: " + droplet.getName(),


### PR DESCRIPTION
the cloud-stats plugin is fairly handy to track cloud availability. for it
to work we'll need to pass a ProvisioningActivity id from the cloud all
the way through to the Computer. Slave and Computer become TrackedItems.