### PR TITLE
log premature return from computer launching

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/ComputerLauncher.java
@@ -159,10 +159,12 @@ public class ComputerLauncher extends hudson.slaves.ComputerLauncher {
             final SCPClient scp = conn.createSCPClient();
 
             if (!runInitScript(computer, logger, conn, scp)) {
+                LOGGER.severe("Failed to launch: Init script failed to run " + computer.getName());
                 return;
             }
 
             if (!installJava(logger, conn)) {
+                LOGGER.severe("Failed to launch: java installation failed to run " + computer.getName());
                 return;
             }
 


### PR DESCRIPTION
returning because a sub-function failed is all nice and dandy, given
the listener logger is ephemeral, not leaving persistent information as
to why the launch failed is getting in the way of debugging.
the only way to figure out what happened after the fact is looking at the
jenkins log it seems.

to enable finding out why launching failed log what went wrong before
returning