### PR TITLE
codify the droplet type (regular, high-cpu, high-mem) in the label string

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -200,14 +200,24 @@ public final class DigitalOcean {
             memoryUnits = "gb";
         }
 
-        return String.format("$%s/month ($%s/hour): %d%s RAM, %d CPU, %dgb Disk, %dtb Transfer",
+        final String slug = size.getSlug();
+        String type = "Regular";
+        if (slug.startsWith("c-")) {
+            type = "High CPU";
+        } else if (slug.startsWith("m-")) {
+            type = "High Memory";
+        }
+
+        return String.format("$%s/month ($%s/hour): %d%s RAM, %d CPU, %dgb Disk, %dtb Transfer (%s)",
                 size.getPriceMonthly().toString(),
                 size.getPriceHourly().toString(),
                 memory,
                 memoryUnits,
                 size.getVirutalCpuCount(),
                 size.getDiskSize(),
-                size.getTransfer());
+                size.getTransfer(),
+                type
+        );
     }
 
     static List<Key> getAvailableKeys(String authToken) throws RequestUnsuccessfulException, DigitalOceanException {


### PR DESCRIPTION
DO a while ago introduced special droplet variants without cpu stealing or
with enormous amounts of ram. They are listed along the regular sizes which
makes them hard to spot in the list. As they have different pricing and
resource behavior than regular nodes it makes sense to more clearly
indicate which is which.