### PR TITLE
do not catch an exception and then return true

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -283,6 +283,7 @@ public class Cloud extends hudson.slaves.Cloud {
                 }
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, e.getMessage(), e);
+                return false;
             }
 
             return true;


### PR DESCRIPTION
previously it could have happened that an unexpected exception was thrown,
caught, logged, but then we'd still have returned true on canProvision.