### PR TITLE
do not attempt to list ssh keys without auth token

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/Cloud.java
@@ -457,11 +457,16 @@ public class Cloud extends hudson.slaves.Cloud {
         }
 
         public ListBoxModel doFillSshKeyIdItems(@QueryParameter String authToken) throws RequestUnsuccessfulException, DigitalOceanException {
-            List<Key> availableSizes = DigitalOcean.getAvailableKeys(authToken);
             ListBoxModel model = new ListBoxModel();
+            if (authToken.isEmpty()) {
+                // Do not even attempt to list the keys if we know the authToken isn't going to work.
+                // It only produces useless errors.
+                return model;
+            }
 
-            for (Key image : availableSizes) {
-                model.add(image.getName() + " (" + image.getFingerprint() + ")", image.getId().toString());
+            List<Key> availableSizes = DigitalOcean.getAvailableKeys(authToken);
+            for (Key key : availableSizes) {
+                model.add(key.getName() + " (" + key.getFingerprint() + ")", key.getId().toString());
             }
 
             return model;


### PR DESCRIPTION
when creating a new DO cloud doFillSshKeyIdItems will be called initially,
with an empty authToken. attempting to list the sshkeys then will cause
an exception, which not only looks silly and screws up the config page,
it also seems to confuse stapler/jelly over when to reload the model
(most times for me entering an auth key did not actually trigger a reload)

by only filling the sshkey model if we got a !empty key, reloading seems
overall more consistent and adding a new cloud doesn't greet the user with
an ugly unhandled exception error.

(also changed the iter variable name from image to key :O)