### PR TITLE
Repeatable template

### DIFF
--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
@@ -63,7 +63,8 @@
     <f:validateButton title="Test connection" progress="Testing API connectivity..." method="testConnection" with="authToken"/>
 
     <f:entry title="Droplets" description="List of droplets which can be launched as slaves">
-        <f:repeatableProperty field="templates">
+        <!-- Defines a header so the repeats can be re-ordered -->
+        <f:repeatableProperty field="templates" header="Droplet">
             <f:entry title="">
                 <div align="right">
                     <f:repeatableDeleteButton/>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/Cloud/config.jelly
@@ -63,9 +63,13 @@
     <f:validateButton title="Test connection" progress="Testing API connectivity..." method="testConnection" with="authToken"/>
 
     <f:entry title="Droplets" description="List of droplets which can be launched as slaves">
-        <f:repeatable field="templates">
-            <st:include page="/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly" class="com.dubture.jenkins.digitalocean.SlaveTemplate$DescriptorImpl"/>
-        </f:repeatable>
+        <f:repeatableProperty field="templates">
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton/>
+                </div>
+            </f:entry>
+        </f:repeatableProperty>
     </f:entry>
 
 </j:jelly>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -27,74 +27,64 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <table width="100%">
+    <f:entry title="Unique name" field="name">
+        <f:textbox/>
+    </f:entry>
 
-        <f:entry title="Unique name" field="name">
-            <f:textbox/>
-        </f:entry>
+    <f:entry title="Image" field="imageId">
+        <f:select />
+    </f:entry>
 
-        <f:entry title="Image" field="imageId">
-            <f:select />
-        </f:entry>
+    <f:entry title="Size" field="sizeId">
+        <f:select />
+    </f:entry>
 
-        <f:entry title="Size" field="sizeId">
-            <f:select />
-        </f:entry>
+    <f:entry title="Region" field="regionId">
+        <f:select />
+    </f:entry>
 
-        <f:entry title="Region" field="regionId">
-            <f:select />
-        </f:entry>
+    <f:entry title="Run as user" field="username">
+        <f:textbox default="root" />
+    </f:entry>
 
-        <f:entry title="Run as user" field="username">
-            <f:textbox default="root" />
-        </f:entry>
+    <f:entry title="Jenkins workspace directory path" field="workspacePath">
+        <f:textbox default="/jenkins/" />
+    </f:entry>
 
-        <f:entry title="Jenkins workspace directory path" field="workspacePath">
-            <f:textbox default="/jenkins/" />
-        </f:entry>
+    <f:entry title="SSH port" field="sshPort">
+        <f:textbox default="22" />
+    </f:entry>
 
-        <f:entry title="SSH port" field="sshPort">
-            <f:textbox default="22" />
-        </f:entry>
+    <f:entry title="Labels" field="labelString">
+        <f:textbox/>
+    </f:entry>
 
-        <f:entry title="Labels" field="labelString">
-            <f:textbox/>
-        </f:entry>
+    <f:entry title="Allow jobs with no label restriction" field="labellessJobsAllowed">
+        <f:checkbox/>
+    </f:entry>
 
-        <f:entry title="Allow jobs with no label restriction" field="labellessJobsAllowed">
-            <f:checkbox/>
-        </f:entry>
+    <f:entry title="Number of executors" field="numExecutors">
+        <f:textbox default="1" />
+    </f:entry>
 
-        <f:entry title="Number of executors" field="numExecutors">
-            <f:textbox default="1" />
-        </f:entry>
+    <f:entry title="Idle termination time" field="idleTerminationInMinutes">
+        <f:textbox default="10" />
+    </f:entry>
 
-        <f:entry title="Idle termination time" field="idleTerminationInMinutes">
-            <f:textbox default="10" />
-        </f:entry>
+    <f:entry title="Instance cap" field="instanceCap">
+        <f:textbox default="2"/>
+    </f:entry>
 
-        <f:entry title="Instance cap" field="instanceCap">
-            <f:textbox default="2"/>
-        </f:entry>
+    <f:entry title="Install monitoring" field="installMonitoring">
+        <f:checkbox/>
+    </f:entry>
 
-        <f:entry title="Install monitoring" field="installMonitoring">
-             <f:checkbox/>
-        </f:entry>
+    <f:entry title="User data" field="userData">
+        <f:textarea/>
+    </f:entry>
 
-        <f:entry title="User data" field="userData">
-            <f:textarea/>
-        </f:entry>
-
-        <f:entry title="Init script" field="initScript">
-            <f:textarea/>
-        </f:entry>
-
-        <f:entry title="">
-            <div align="right">
-                <f:repeatableDeleteButton />
-            </div>
-        </f:entry>
-
-    </table>
+    <f:entry title="Init script" field="initScript">
+        <f:textarea/>
+    </f:entry>
 
 </j:jelly>


### PR DESCRIPTION
use repeatableProperty to render the slave template config.jelly

SlaveTemplate is a describable so we can let repeatableProperty do the
heavy lifting of loading the right config.jelly with the right descriptor
scoping.
    
Also, move delete button out of the SlaveTemplate config.jelly to
the Cloud's. Defining the button in the describable itself is deprecated.

repeatableProperty can add a handle to re-order repeatables if a header
is defined. as this can be handy to manage a greater number of droplets
to sort them in a more logical/human readable order, set a simple header
to get this feature enabled.
