### PR TITLE
Allow specification of DigitalOcean Droplet tags

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -27,6 +27,7 @@
 package com.dubture.jenkins.digitalocean;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -116,6 +117,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     private final Boolean installMonitoringAgent;
 
+    private final String tags;
+
     /**
      * User-supplied data for configuring a droplet
      */
@@ -140,14 +143,15 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param numExecutors the number of executors that this slave supports
      * @param labelString the label for this slave
      * @param installMonitoring whether expanded monitoring tool agent should be installed
+     * @param tags the droplet tags
      * @param userData user data for DigitalOcean to apply when building the slave
      * @param initScript setup script to configure the slave
      */
     @DataBoundConstructor
     public SlaveTemplate(String name, String imageId, String sizeId, String regionId, String username, String workspacePath,
                          Integer sshPort, String idleTerminationInMinutes, String numExecutors, String labelString,
-                         Boolean labellessJobsAllowed, String instanceCap, Boolean installMonitoring, String userData,
-                         String initScript) {
+                         Boolean labellessJobsAllowed, String instanceCap, Boolean installMonitoring, String tags,
+                         String userData, String initScript) {
 
         LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}",
                 new Object[] { imageId, sizeId, regionId});
@@ -167,6 +171,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.labels = Util.fixNull(labelString);
         this.instanceCap = Integer.parseInt(instanceCap);
         this.installMonitoringAgent = installMonitoring;
+        this.tags = tags;
 
         this.userData = userData;
         this.initScript = initScript;
@@ -236,6 +241,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setKeys(newArrayList(new Key(sshKeyId)));
             droplet.setEnablePrivateNetworking(usePrivateNetworking);
             droplet.setInstallMonitoring(installMonitoringAgent);
+            droplet.setTags(Arrays.asList(Util.tokenize(Util.fixNull(tags))));
 
             if (!(userData == null || userData.trim().isEmpty())) {
                 droplet.setUserData(userData);
@@ -498,6 +504,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public boolean isInstallMonitoring() {
         return installMonitoringAgent;
+    }
+
+    public String getTags() {
+        return tags;
     }
 
     public String getUserData() {

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -79,6 +79,10 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:entry title="Droplet Tags" field="tags">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="User data" field="userData">
         <f:textarea/>
     </f:entry>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-tags.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-tags.html
@@ -1,0 +1,29 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2014 robert.gruendler@dubture.com
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+	DigitalOcean offers tags, a feature allowing you to apply custom labels to a Droplet. Tags may contain letters,
+	numbers, colons, dashes, and underscores. Use spaces between each tag. For instance 'jenkins dev' will assign a
+	droplet the tags 'jenkins' and 'dev'.
+</div>


### PR DESCRIPTION
DigitalOcean has the ability to specify network firewalls which are linked to tags, both for the droplets to apply the firewall to, and for the traffic sources.

To take advantage of that, I needed to tag droplets created by this plugin.

The change introduces a new "tags" field, the values of which are passed into the DigitalOcean API.