### PR TITLE
Fix display of "Install monitoring" setting.

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -496,6 +496,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return instanceCap;
     }
 
+    public boolean isInstallMonitoring() {
+        return installMonitoringAgent;
+    }
+
     public String getUserData() {
         return userData;
     }


### PR DESCRIPTION
When adding support for tags, I noticed the current value of "Install Monitoring" was not displayed when updating the configuration.