### PR TITLE
fix instanceCap resetting to default value every time you open /configure

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOceanCloud.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOceanCloud.java
@@ -353,7 +353,7 @@ public class DigitalOceanCloud extends Cloud {
         return sshKeyId;
     }
 
-    private int getInstanceCap() {
+    public int getInstanceCap() {
         return instanceCap;
     }
 


### PR DESCRIPTION
getters need to be public since they get called by jelly render to actually
get the runtime value of the associated entry field.
because getInstanceCap was private the currnet value couldn't be
retrieved and the config view was always initialized to the default value
of 5.

simply make the getter public again.
this broken in some style fixes I did before 0.15.