### PR TITLE
Added an option allowing private networking inspite of master/slave communication

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -113,6 +113,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     private final String workspacePath;
 
     private final Integer sshPort;
+    
+    private final Boolean setupPrivateNetworking;
 
     private final Integer instanceCap;
 
@@ -156,7 +158,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      */
     @DataBoundConstructor
     public SlaveTemplate(String name, String imageId, String sizeId, String regionId, String username, String workspacePath,
-                         Integer sshPort, String idleTerminationInMinutes, String numExecutors, String labelString,
+                         Integer sshPort, Boolean setupPrivateNetworking, String idleTerminationInMinutes, String numExecutors, String labelString,
                          Boolean labellessJobsAllowed, String instanceCap, Boolean installMonitoring, String tags,
                          String userData, String initScript) {
 
@@ -170,7 +172,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         this.username = username;
         this.workspacePath = workspacePath;
         this.sshPort = sshPort;
-
+        this.setupPrivateNetworking = setupPrivateNetworking;
+        
         this.idleTerminationInMinutes = tryParseInteger(idleTerminationInMinutes, 10);
         this.numExecutors = tryParseInteger(numExecutors, 1);
         this.labelString = labelString;
@@ -246,7 +249,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setRegion(new Region(regionId));
             droplet.setImage(DigitalOcean.newImage(imageId));
             droplet.setKeys(newArrayList(new Key(sshKeyId)));
-            droplet.setEnablePrivateNetworking(usePrivateNetworking);
+            droplet.setEnablePrivateNetworking(usePrivateNetworking || setupPrivateNetworking);
             droplet.setInstallMonitoring(installMonitoringAgent);
             droplet.setTags(Arrays.asList(Util.tokenize(Util.fixNull(tags))));
 
@@ -527,6 +530,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     public int getSshPort() {
         return sshPort;
     }
+    
+    public boolean isSetupPrivateNetworking() { return setupPrivateNetworking; }
 
     private static int tryParseInteger(final String integerString, final int defaultValue) {
         try {

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -54,6 +54,10 @@
     <f:entry title="SSH port" field="sshPort">
         <f:textbox default="22" />
     </f:entry>
+    
+    <f:entry title="Setup Private Networking" field="setupPrivateNetworking">
+        <f:checkbox/>
+    </f:entry>
 
     <f:entry title="Labels" field="labelString">
         <f:textbox/>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-setupPrivateNetworking.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-setupPrivateNetworking.html
@@ -23,7 +23,7 @@
   -->
 
 <div>
-    On this droplet, setup an network interface to facilitate internal communication between droplets.
+    On this droplet, setup a network interface to facilitate internal communication between droplets.
     Note: this does not effect how the Jenkins master communicates with this slave, that is a separate 
     setting in the top-level "Cloud" settings. Traffic between droplets over private networking does not
     count against transfer limits. This is not a measure of security, private networking is shared across

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-setupPrivateNetworking.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-setupPrivateNetworking.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 Harald Sitter <sitter@kde.org>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    On this droplet, setup an network interface to facilitate internal communication between droplets.
+    Note: this does not effect how the Jenkins master communicates with this slave, that is a separate 
+    setting in the top-level "Cloud" settings. Traffic between droplets over private networking does not
+    count against transfer limits. This is not a measure of security, private networking is shared across
+    all droplets in a data center.
+</div>


### PR DESCRIPTION
This option allows one to enable private networking on their slave
regardless of whether or not the master will communicate with it
over the internal network.

This comes in handy for build tasks that will execute on the slaves that
need to communicate to a (static) droplet. For instance, pushing to or
pulling from an internal maven repo.