### PR TITLE
optionally allow image resolution by name

### DIFF
--- a/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/SlaveTemplate.java
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2014 robert.gruendler@dubture.com
  *               2016 Maxim Biro <nurupo.contributions@gmail.com>
- *               2017 Harald Sitter <sitter@kde.org>
+ *               2017, 2021 Harald Sitter <sitter@kde.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -93,6 +93,8 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     private final Boolean labellessJobsAllowed;
 
+    private final Boolean imageByName;
+
     /**
      * The Image to be used for the droplet.
      */
@@ -155,17 +157,19 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      * @param tags the droplet tags
      * @param userData user data for DigitalOcean to apply when building the slave
      * @param initScript setup script to configure the slave
+     * @param imageByName whether to resolve the image by name rather than id
      */
     @DataBoundConstructor
     public SlaveTemplate(String name, String imageId, String sizeId, String regionId, String username, String workspacePath,
                          Integer sshPort, Boolean setupPrivateNetworking, String idleTerminationInMinutes, String numExecutors, String labelString,
                          Boolean labellessJobsAllowed, String instanceCap, Boolean installMonitoring, String tags,
-                         String userData, String initScript) {
+                         String userData, String initScript, Boolean imageByName) {
 
         LOGGER.log(Level.INFO, "Creating SlaveTemplate with imageId = {0}, sizeId = {1}, regionId = {2}",
                 new Object[] { imageId, sizeId, regionId});
 
         this.name = name;
+        this.imageByName = imageByName;
         this.imageId = imageId;
         this.sizeId = sizeId;
         this.regionId = regionId;
@@ -257,7 +261,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             droplet.setName(dropletName);
             droplet.setSize(sizeId);
             droplet.setRegion(new Region(regionId));
-            droplet.setImage(DigitalOcean.newImage(imageId));
+            droplet.setImage(DigitalOcean.newImage(authToken, imageId, imageByName));
             droplet.setKeys(Arrays.asList(new Key(sshKeyId)));
             droplet.setInstallMonitoring(installMonitoringAgent);
             droplet.setEnablePrivateNetworking(
@@ -442,22 +446,21 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             return model;
         }
 
-        public ListBoxModel doFillImageIdItems(@RelativePath("..") @QueryParameter String authTokenCredentialId) throws Exception {
-
+        public ListBoxModel doFillImageIdItems(@RelativePath("..") @QueryParameter String authTokenCredentialId, @QueryParameter Boolean imageByName) throws Exception {
             ListBoxModel model = new ListBoxModel();
-            String authToken = DigitalOceanCloud.getAuthTokenFromCredentialId(authTokenCredentialId);
+            final String authToken = DigitalOceanCloud.getAuthTokenFromCredentialId(authTokenCredentialId);
             if (StringUtils.isBlank(authToken)) {
               return model;
             }
 
-            SortedMap<String, Image> availableImages = DigitalOcean.getAvailableImages(DigitalOceanCloud.getAuthTokenFromCredentialId(authTokenCredentialId));
+            final SortedMap<String, Image> availableImages = imageByName ? DigitalOcean.getAvailableUserImages(authToken) : DigitalOcean.getAvailableImages(authToken);
 
             for (Map.Entry<String, Image> entry : availableImages.entrySet()) {
                 final Image image = entry.getValue();
 
                 // For non-snapshots, use the image ID instead of the slug (which isn't available anyway)
                 // so that we can build images based upon backups.
-                final String value = DigitalOcean.getImageIdentifier(image);
+                final String value = imageByName ? image.getName() : DigitalOcean.getImageIdentifier(image);
 
                 model.add(entry.getKey(), value);
             }
@@ -513,6 +516,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
     public Set<LabelAtom> getLabelSet() {
         return labelSet;
+    }
+
+    public Boolean getImageByName() {
+        return imageByName;
     }
 
     public String getImageId() {

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/config.jelly
@@ -3,6 +3,7 @@
   ~
   ~ Copyright (c) 2014 robert.gruendler@dubture.com
   ~               2016 Maxim Biro <nurupo.contributions@gmail.com>
+  ~               2021 Harald Sitter <sitter@kde.org>
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +32,10 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="Resolve user image by name rather than ID or slug" field="imageByName">
+        <f:checkbox/>
+    </f:entry>
+
     <f:entry title="Image" field="imageId">
         <f:select />
     </f:entry>
@@ -54,7 +59,7 @@
     <f:entry title="SSH port" field="sshPort">
         <f:textbox default="22" />
     </f:entry>
-    
+
     <f:entry title="Setup Private Networking" field="setupPrivateNetworking">
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-imageByName.html
+++ b/src/main/resources/com/dubture/jenkins/digitalocean/SlaveTemplate/help-imageByName.html
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2021 Harald Sitter <sitter@kde.org>
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Always resolves the actually used image through its name. Usually images are either resolved through their slug
+    or their unique id. The only reason to opt into resolution by name is when you recreate snapshots using the same
+    name to force updates into the cloud nodes. If multiple images are present the newest is used.
+
+    <p>This option may only be used with user images, not base images provided by DigitalOcean!</p>
+</div>


### PR DESCRIPTION
this enables a use case where one would continuously update the image
and re-create it as a new snapshot, causing the id to constantly change
but the name to be persistent. since ordinarily name is a really poor
way to resolve images, in particular also because we always need to talk
to the api to get the actual image, this entire feature is limited to
user images rather than all images. specifically this also lessens the
API work we need to do.

the template config has a new checkbox to enable this feature, which
then prompts a reload of the image combobox to only include user images
(and at the same time the values in the model are changed from slugOrIds
to names)

at provisioning time we then need to pass a bit more context along so as
to resolve accordingly in newImage()

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
