### PR TITLE
JENKINS-68953 - No longer crash when fetching sizes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.myjeeva.digitalocean</groupId>
+            <groupId>com.gavinmogan.digitalocean</groupId>
             <artifactId>digitalocean-api-client</artifactId>
-            <version>2.17</version>
+            <version>2.18</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloud-stats</artifactId>
             <version>0.26</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>trilead-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -80,6 +84,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
+++ b/src/main/java/com/dubture/jenkins/digitalocean/DigitalOcean.java
@@ -198,7 +198,7 @@ public final class DigitalOcean {
             type = "High Memory";
         }
 
-        return String.format("$%s/month ($%s/hour): %d%s RAM, %d CPU, %dgb Disk, %dtb Transfer (%s)",
+        return String.format("$%s/month ($%s/hour): %d%s RAM, %d CPU, %dgb Disk, %.2ftb Transfer (%s)",
                 size.getPriceMonthly().toString(),
                 size.getPriceHourly().toString(),
                 memory,
@@ -266,15 +266,7 @@ public final class DigitalOcean {
     }
 
     static Image newImage(String idOrSlug) {
-        Image image;
-
-        try {
-            image = new Image(Integer.parseInt(idOrSlug));
-        }
-        catch (NumberFormatException e) {
-            image = new Image(idOrSlug);
-        }
-
+        Image image = new Image(idOrSlug);
         return image;
     }
 


### PR DESCRIPTION
DigitalOcean's size api updated the transfer field from being an integer to a float.

This was submitted to the upstream library - https://github.com/jeevatkm/digitalocean-api-java/pull/123

To unblock people, I've forked the library and released my own fork