### PR TITLE
Add tests to confirm the casc example in readme works

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jenkins.save()
 jenkins:
   clouds:
     - digitalOcean:
-        authToken: "01234567890123456789012345678901234567890123456789",
+        authToken: "01234567890123456789012345678901234567890123456789"
         connectionRetryWait: 10
         instanceCap: 5
         name: "mycompany"
@@ -133,7 +133,7 @@ jenkins:
           Ce1kzwKacU+b/2xhAkEAovqzUMFB9YEbc8C9AzTej5F2ttyuKBDJJ+kvQeJP+PnW
           4ovFI4Ee5UmTWI6k/Md9BM+MvEMWs3nPoF4MULHqNg==
           -----END RSA PRIVATE KEY-----
-        sshKeyId: 1234567,
+        sshKeyId: 1234567
         templates:
           - idleTerminationInMinutes: 10
             imageId: "docker-20-04"

--- a/src/test/java/com/dubture/jenkins/digitalocean/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/dubture/jenkins/digitalocean/ConfigurationAsCodeTest.java
@@ -1,31 +1,24 @@
 package com.dubture.jenkins.digitalocean;
 
-import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import jenkins.model.Jenkins;
-import hudson.util.Secret;
-import hudson.model.labels.LabelAtom;
-import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
-import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import io.jenkins.plugins.casc.ConfiguratorRegistry;
-import io.jenkins.plugins.casc.ConfigurationContext;
-import io.jenkins.plugins.casc.model.CNode;
-
 import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
-import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
-
-import org.junit.Rule;
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
 
 public class ConfigurationAsCodeTest {
 
@@ -63,6 +56,52 @@ public class ConfigurationAsCodeTest {
         assertEquals(2, slaveTemplate.getNumExecutors());
         assertEquals("tor1", slaveTemplate.getRegionId());
         assertEquals("s-2vcpu-2gb", slaveTemplate.getSizeId());
+        assertEquals(22, slaveTemplate.getSshPort());
+        assertEquals(null, slaveTemplate.getTags());
+        assertEquals(null, slaveTemplate.getUserData());
+        assertEquals("root", slaveTemplate.getUsername());
+        assertEquals("/jenkins/", slaveTemplate.getWorkspacePath());
+    }
+
+    @Test
+    @ConfiguredWithCode("legacy-pre-credentials.yml")
+    public void testLegacyPreCredentials() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        String exported = toYamlString(getJenkinsRoot(context).get("clouds"));
+
+        assertThat(exported, CoreMatchers.containsString("authTokenCredentialId:"));
+        assertThat(exported, CoreMatchers.not(CoreMatchers.containsString("authToken:")));
+
+        assertThat(exported, CoreMatchers.containsString("privateKeyCredentialId:"));
+        assertThat(exported, CoreMatchers.not(CoreMatchers.containsString("privateKey:")));
+
+        final DigitalOceanCloud doCloud = (DigitalOceanCloud) Jenkins.get().getCloud("mycompany");
+        assertNotNull(doCloud);
+
+        final List<SlaveTemplate> templates = doCloud.getTemplates();
+        assertEquals(1, templates.size());
+        assertNotEquals("", doCloud.getPrivateKeyCredentialId());
+        assertEquals("", doCloud.getPrivateKey());
+        assertNotNull("", DigitalOceanCloud.getPrivateKeyFromCredentialId(doCloud.getPrivateKeyCredentialId()));
+        assertNotEquals("", doCloud.getAuthTokenCredentialId());
+        assertEquals("", doCloud.getAuthToken());
+        assertNotEquals("", DigitalOceanCloud.getAuthTokenFromCredentialId(doCloud.getAuthTokenCredentialId()));
+
+        SlaveTemplate slaveTemplate;
+
+        slaveTemplate = templates.get(0);
+        assertEquals(10, slaveTemplate.getIdleTerminationInMinutes());
+        assertEquals("docker-20-04", slaveTemplate.getImageId());
+        assertEquals(null, slaveTemplate.getInitScript());
+        assertEquals(2, slaveTemplate.getInstanceCap());
+        assertEquals(Collections.emptySet(), slaveTemplate.getLabelSet());
+        assertEquals(null, slaveTemplate.getLabelString());
+        assertEquals("", slaveTemplate.getLabels());
+        assertEquals("docker-20-04", slaveTemplate.getName());
+        assertEquals(1, slaveTemplate.getNumExecutors());
+        assertEquals("tor1", slaveTemplate.getRegionId());
+        assertEquals("s-1vcpu-1gb", slaveTemplate.getSizeId());
         assertEquals(22, slaveTemplate.getSshPort());
         assertEquals(null, slaveTemplate.getTags());
         assertEquals(null, slaveTemplate.getUserData());

--- a/src/test/resources/com/dubture/jenkins/digitalocean/legacy-pre-credentials.yml
+++ b/src/test/resources/com/dubture/jenkins/digitalocean/legacy-pre-credentials.yml
@@ -1,0 +1,44 @@
+configuration-as-code:
+  deprecated: warn
+jenkins:
+  clouds:
+    - digitalOcean:
+        authToken: "01234567890123456789012345678901234567890123456789"
+        connectionRetryWait: 10
+        instanceCap: 5
+        name: "mycompany"
+        privateKey: |
+          ----BEGIN RSA PRIVATE KEY-----
+          MIICWwIBAAKBgGuoiHtwl8T2cKfclsWLOcv8S6p74iOAQX1kwCLvLy7ioDFlNzsI
+          U235N1StnZYZIwGla+3Uo3jMSUuWkMH85+d3KoRFPS+6RJCiAvMI0hr8FByes22v
+          DAVDnhkZ2SFOeh1SPxWDygPo2fW5sgqL2eYLO1CplDdqYhHLAL1FDV5tAgMBAAEC
+          gYBWRZoJgXK9zdb9TZIs/6LzSlzAY8IWPOM+PwyRcibXZZiFvNyDm+pviHTEkNRl
+          wgMBgLR6xBmz5dEel6utKKQVEPtD1m6N+z6hwUw+Nis35DCvmBX+hQSK+atGgjYH
+          ZKz0oqWUSuzHG+CxxcrePDTYJ4fdSyLPsQqaWoCZseDDwQJBANLey9r+juBEQe2N
+          MJoZTU1q/AoS5kY7OWQ1aF495I9fz87u9vx8BJh8djvmABwidUWREnd4vwwEIS3M
+          JtFGn+kCQQCCsvBvOXgVAlcR54/6ro6R42/0F3bZw0ZFVXvgRRjCZW6m4FyHq4AL
+          +gfAV0HERkMdlO1zBpBwkSURekDc9NvlAkAA3zj6k9jlZoLbR50u1fHy4wFdzUw0
+          eCQ5nNrsoNbkHOJQGb7dtmmSc9lNUBsqAp53hi0MX2xy0UWN2e1DKkaZAkBi9stH
+          7OQYRGVZkVVcI8Cghu7GjN3ZlhsndMsPzkIpMFTQ1yI5OIsEhpZH9co+rFU1mQcT
+          Ce1kzwKacU+b/2xhAkEAovqzUMFB9YEbc8C9AzTej5F2ttyuKBDJJ+kvQeJP+PnW
+          4ovFI4Ee5UmTWI6k/Md9BM+MvEMWs3nPoF4MULHqNg==
+          -----END RSA PRIVATE KEY-----
+        sshKeyId: 1234567
+        templates:
+          - idleTerminationInMinutes: 10
+            imageId: "docker-20-04"
+            installMonitoring: false
+            instanceCap: 2
+            labellessJobsAllowed: false
+            name: "docker-20-04"
+            numExecutors: 1
+            regionId: "tor1"
+            setupPrivateNetworking: false
+            sizeId: "s-1vcpu-1gb"
+            sshPort: 22
+            username: "root"
+            workspacePath: "/jenkins/"
+        timeoutMinutes: 5
+        usePrivateNetworking: false
+
+


### PR DESCRIPTION
Add back in allowing plaintext ssh keys and do token, but only in casc, not in the ui

Fix example in readme.